### PR TITLE
add CIMReader as non-standard - version from pom

### DIFF
--- a/non-standard.json
+++ b/non-standard.json
@@ -24,6 +24,7 @@
   "com.tradeshift ts-reaktive-testkit-assertj":      "java",
   "amplab spark-indexedrdd":                         "pom",
   "me.leaf akka-persistence-android":                "pom",
+  "ch.ninecode.cim CIMReader":                       "pom",
   "io.gatling gatling-app":                          "pom",
   "io.gatling gatling-bundle":                       "pom",
   "io.gatling gatling-charts":                       "pom",


### PR DESCRIPTION
Scaladex is still not indexing [CIMReader](http://search.maven.org/#search%7Cga%7C1%7CCIMReader), so try adding it as a non-standard named artifact.

I'm not sure if the maven pom code will replace properties, i.e. `${version.dependency.scalalibrary}` but we can try it and see.