### PR TITLE
claim the cc.drx suite of scala libs

### DIFF
--- a/claims.json
+++ b/claims.json
@@ -78,6 +78,7 @@
   "build.unstable tylog-macros*": "scalacenter/scaladex-void",
   "build.unstable tylog*": "scalacenter/scaladex-void",
   "ca.marvelmathew gcm-scala_*": "marvelm/gcm-scala",
+  "cc.drx *": "drxcc/drx",
   "cc.p2k centrality_*": "webgeist/Centrality",
   "cc.p2k spark-centrality*": "scalacenter/scaladex-void",
   "cc.p2k yahoo-finance_*": "webgeist/yahoo-finance",


### PR DESCRIPTION
There are a number of projects cross compiled under the `cc.drx` organization.  `core` is the most frequently used but other common projects are `archive` and `p5`.  However, each project should be directed to the main https://github.com/drxcc/drx landing project/page.  This landing page will direct to the http://drx.cc/api page where all the libraries are grouped together in a unified `unidoc`.