### PR TITLE
Add sbt-bintray after rename

### DIFF
--- a/claims.json
+++ b/claims.json
@@ -2134,6 +2134,7 @@
   "org.duhemm plugin_*": "Duhemm/parsermacros",
   "org.ensime sbt-ensime": "ensime/ensime-sbt",
   "org.flywaydb flyway-play_*": "flyway/flyway-play",
+  "org.foundweekends sbt-bintray": "sbt/sbt-bintray",
   "org.foundweekends.conscript sbt-conscript": "scalacenter/scaladex-void",
   "org.foundweekends.giter8 sbt-giter8": "scalacenter/scaladex-void",
   "org.foundweekends.giter8 sbt-giter8-scaffold": "scalacenter/scaladex-void",


### PR DESCRIPTION
Currently scaladex only has sbt-bintray versions until 0.3 (before artifact rename). This should bring latest versions back to scaladex.