### PR TITLE
Point third-party fork of sbt-dependency-graph to the right project

### DIFF
--- a/claims.json
+++ b/claims.json
@@ -2145,6 +2145,7 @@
   "org.github.mansur.scalastyle gradle-scalastyle-plugin*": "scalacenter/scaladex-void",
   "org.github.ngbinh.scalastyle gradle-scalastyle-plugin*": "ngbinh/gradle-scalastyle-plugin",
   "org.h3nk3 sbt-ortho": "henrikengstrom/sbt-ortho",
+  "org.hammerlab sbt-dependency-graph": "hammerlab/sbt-dependency-graph",
   "org.homermultitext hmt-textmodel*": "scalacenter/scaladex-void",
   "org.homermultitext hmt_textmodel*": "scalacenter/scaladex-void",
   "org.http4s jawn-fs2*": "scalacenter/scaladex-void",


### PR DESCRIPTION
https://index.scala-lang.org/jrudolph/sbt-dependency-graph/sbt-dependency-graph/0.10.2

points to this artifact:

```
addSbtPlugin("org.hammerlab" % "sbt-dependency-graph" % "0.10.2")
```

probably, because that forked version was published without adapting the scm info.

Is that the right way to overwrite the scmInfo for the fork, so that it won't show up for jrudolph/sbt-dependency-graph any more?

It's not a super big deal for me, but it means that I could otherwise not use the latest badge.