### PR TITLE
Add sbt-scripted-scalatest

### DIFF
--- a/claims.json
+++ b/claims.json
@@ -355,6 +355,7 @@
   "com.github.cuzfrog excela*": "cuzfrog/excela",
   "com.github.cuzfrog maila*": "cuzfrog/maila",
   "com.github.cuzfrog sormc*": "cuzfrog/sormc",
+  "com.github.daniel-shuy sbt-scripted-scalatest": "daniel-shuy/scripted-scalatest-sbt-plugin",
   "com.github.dannywe honeypot*": "scalacenter/scaladex-not-found",
   "com.github.davidkellis acceptparser*": "scalacenter/scaladex-not-found",
   "com.github.davidkellis query*": "davidkellis/query",


### PR DESCRIPTION
I'm confused if SBT plugins have to be added manually to `claims.json` or they will automatically be indexed from [sbt/sbt-plugin-releases](https://bintray.com/sbt/sbt-plugin-releases). The `README` seems to indicate both (https://github.com/scalacenter/scaladex#user-content-how-it-works).