### PR TITLE
Fix: possible GitHub username case issue for sbt-devoops

### DIFF
--- a/claims.json
+++ b/claims.json
@@ -1670,7 +1670,7 @@
   "io.ipsq 2048-scalajs-facade*": "ipsq/2048-scalajs-facade",
   "io.jenner sbt-jenner": "scalacenter/scaladex-void",
   "io.john-ky hashids-scala*": "scalacenter/scaladex-void",
-  "io.kevinlee sbt-devoops": "Kevin-Lee/sbt-devoops",
+  "io.kevinlee sbt-devoops": "kevin-lee/sbt-devoops",
   "io.linkki linkki*": "scalacenter/scaladex-void",
   "io.megam libcommon_*": "megamsys/megam_common",
   "io.megam newman_*": "megamsys/newman",


### PR DESCRIPTION
Fix: make github username all lower cases for `sbt-devoops` to fix a possible issue with Scaladex not picking it up.

Related to [this issue](https://github.com/scalacenter/scaladex-contrib/pull/53#issuecomment-546831958).